### PR TITLE
Use http batch client

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -135,7 +135,11 @@ const setRPCClients = async (chains) => {
     for (let i = 0; i < chains.length; i++) {
         const address = chains[i].address;
         try {
-            const client = await tendermint_rpc_1.Tendermint34Client.connect(address);
+            const httpBatchClient = new tendermint_rpc_1.HttpBatchClient(address, {
+                batchSizeLimit: 5,
+                dispatchInterval: variables_1.TIMEOUT
+            });
+            const client = await tendermint_rpc_1.Tendermint34Client.create(httpBatchClient);
             const queryClient = stargate_1.QueryClient.withExtensions(client, cosmwasm_stargate_1.setupWasmExtension);
             let rpcConnection = {
                 client,
@@ -204,12 +208,9 @@ const skipRPCs = (rpcs) => {
     let res = [];
     for (let i = 0; i < rpcs.length; i++) {
         const rpc = rpcs[i];
-        console.log('aloha ffs', rpc);
         if (!variables_1.SKIP_RPC_ADDRESSES.includes(rpc.address))
             res.push(rpc);
     }
-    // console.log('aloha rpcs after skipping', rpcs)
-    console.log('aloha rpcs after skipping RES', res);
     return res;
 };
 exports.skipRPCs = skipRPCs;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,10 +6,10 @@ import {
     allRPCConnections,
     blockHeights,
     RPC_LIMIT,
-    setAllRPCConnections, SKIP_RPC_ADDRESSES,
+    setAllRPCConnections, SKIP_RPC_ADDRESSES, TIMEOUT,
     updateBlockHeights, VERBOSITY
 } from "./variables";
-import {BlockResponse, Tendermint34Client, TxResponse} from "@cosmjs/tendermint-rpc";
+import {BlockResponse, HttpBatchClient, Tendermint34Client, TxResponse} from "@cosmjs/tendermint-rpc";
 import {QueryClient} from "@cosmjs/stargate";
 import {
     QueryContractInfoResponse,
@@ -127,7 +127,11 @@ export const setRPCClients = async (chains: Chain[]) => {
     for (let i = 0; i < chains.length; i++) {
         const address = chains[i].address
         try {
-            const client: any = await Tendermint34Client.connect(address)
+            const httpBatchClient = new HttpBatchClient(address, {
+                batchSizeLimit: 5,
+                dispatchInterval: TIMEOUT
+            })
+            const client: any = await Tendermint34Client.create(httpBatchClient)
             const queryClient = QueryClient.withExtensions(client, setupWasmExtension)
             let rpcConnection: RpcConnection = {
                 client,


### PR DESCRIPTION
This is pretty amazing, and based on a discovery someone made. A person from Kujira discovered that in 2019 there was an ability in Tendermint to batch RPC calls, and they made a new client that automatically "pushes" requests to a queue and then will execute them either when the number in the queue hits a certain limit, or when a "timeout interval" is reached.

As you can see from the screenshot in my tweet, this is really impressive and I had to do no work other than simply using it. (That's a lie, I did quite a bit of work to figure out if it was really working, how it was working, and it I needed to modify the Indexer Sweeper in order to use this.)

https://twitter.com/mikedotexe/status/1594919979245514754

You can also see a video of Simon Warta from Confio going over this here, if you're curious:
https://vimeo.com/771505975

Here's how I got the console logs, by "hacking" the build files in `node_modules` the messy way:

<img width="1165" alt="Screen Shot 2022-11-22 at 9 11 14 AM" src="https://user-images.githubusercontent.com/1042667/203378383-ea557328-6418-405f-9244-09bb010c41a2.png">
