### PR TITLE
checkForMissedBlocks is scheduled using nested setTimeout

### DIFF
--- a/build/checkForLatestBlock.js
+++ b/build/checkForLatestBlock.js
@@ -17,12 +17,8 @@ const checkForLatestBlock = async () => {
         // Nothing to see, move along, solider
         return;
     }
-    if (variables_1.lastHeight !== 0 && currentHeight - variables_1.lastHeight !== 1) {
-        await (0, utils_1.checkForMissedBlocks)();
-    }
     // Logic for new block that came in
     (0, variables_1.updateLastHeight)(currentHeight);
-    console.log('New block height:', currentHeight);
     let block;
     try {
         block = await (0, utils_1.getBlockInfo)(currentHeight);

--- a/build/checkForLatestBlock.js
+++ b/build/checkForLatestBlock.js
@@ -19,6 +19,7 @@ const checkForLatestBlock = async () => {
     }
     // Logic for new block that came in
     (0, variables_1.updateLastHeight)(currentHeight);
+    console.log('New block height:', currentHeight);
     let block;
     try {
         block = await (0, utils_1.getBlockInfo)(currentHeight);

--- a/build/index.js
+++ b/build/index.js
@@ -41,7 +41,7 @@ const setup = async () => {
     // Fill out extra transaction detail (gas used vs wanted, etc.)
     setInterval(() => (0, addTxDetail_1.addTxDetail)(), variables_1.TIMEOUT * 2);
     // Check for gaps in blocks
-    setInterval(() => (0, utils_1.checkForMissedBlocks)(), variables_1.TIMEOUT * 2);
+    (0, variables_1.updateBlocksTimerId)(setTimeout(utils_1.checkForMissedBlocks, variables_1.TIMEOUT * 2));
     // Check for fk_contract_id in messages
     setInterval(() => (0, addContractId_1.addContractId)(), variables_1.TIMEOUT * 2);
     // Check for synced blocks

--- a/build/utils.js
+++ b/build/utils.js
@@ -116,6 +116,7 @@ const checkForMissedBlocks = async () => {
             const blockTime = block.block.header.time;
             const isoBlockTime = new Date(blockTime.toISOString()).toISOString();
             (0, exports.v)('isoBlockTime', isoBlockTime);
+            console.log('Fixing missed block', missingBlockNum);
             await (0, checkForLatestBlock_1.handleBlockTxs)(missingBlockNum, blockTxs, isoBlockTime);
         }
     }

--- a/build/variables.js
+++ b/build/variables.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.db = exports.updateStateTimerId = exports.getStateTimerId = exports.updateLastHeight = exports.lastHeight = exports.updateBlockHeights = exports.blockHeights = exports.contractAddresses = exports.settings = exports.ADD_RPC_ADDRESSES_ALWAYS = exports.ADD_RPC_ADDRESSES = exports.SKIP_RPC_ADDRESSES = exports.VERBOSITY = exports.CHAIN_REGISTRY_URLS = exports.CACHE_LIMIT = exports.RPC_LIMIT = exports.TIMEOUT_CHECK_CHAIN_REGISTRY = exports.TIMEOUT = exports.setAllRPCConnections = exports.allRPCConnections = exports.agents = exports.emptyHeights = exports.blockMap = exports.CHAIN_ID_PREFIX = exports.CHAIN_ID = void 0;
+exports.db = exports.updateBlocksTimerId = exports.getBlocksTimerId = exports.updateStateTimerId = exports.getStateTimerId = exports.updateLastHeight = exports.lastHeight = exports.updateBlockHeights = exports.blockHeights = exports.contractAddresses = exports.settings = exports.ADD_RPC_ADDRESSES_ALWAYS = exports.ADD_RPC_ADDRESSES = exports.SKIP_RPC_ADDRESSES = exports.VERBOSITY = exports.CHAIN_REGISTRY_URLS = exports.CACHE_LIMIT = exports.RPC_LIMIT = exports.TIMEOUT_CHECK_CHAIN_REGISTRY = exports.TIMEOUT = exports.setAllRPCConnections = exports.allRPCConnections = exports.agents = exports.emptyHeights = exports.blockMap = exports.CHAIN_ID_PREFIX = exports.CHAIN_ID = void 0;
 // Contracts we'll want to look for being called
 const db_1 = require("./db");
 const dotenv_1 = require("dotenv");
@@ -47,4 +47,8 @@ const updateStateTimerId = (newTimer) => {
     exports.getStateTimerId = newTimer;
 };
 exports.updateStateTimerId = updateStateTimerId;
+const updateBlocksTimerId = (newBlocksTimer) => {
+    exports.getBlocksTimerId = newBlocksTimer;
+};
+exports.updateBlocksTimerId = updateBlocksTimerId;
 exports.db = (0, db_1.getDb)();

--- a/src/checkForLatestBlock.ts
+++ b/src/checkForLatestBlock.ts
@@ -37,6 +37,7 @@ export const checkForLatestBlock = async () => {
     }
     // Logic for new block that came in
     updateLastHeight(currentHeight)
+    console.log('New block height:', currentHeight)
     let block: BlockResponse
     try {
         block = await getBlockInfo(currentHeight)

--- a/src/checkForLatestBlock.ts
+++ b/src/checkForLatestBlock.ts
@@ -37,7 +37,6 @@ export const checkForLatestBlock = async () => {
     }
     // Logic for new block that came in
     updateLastHeight(currentHeight)
-    console.log('New block height:', currentHeight)
     let block: BlockResponse
     try {
         block = await getBlockInfo(currentHeight)
@@ -99,6 +98,7 @@ export const handleBlockTxs = async (height: number, blockTxs, isoBlockTime: str
             wasmExecTxs.push(simpleTx)
         }
     })
+
     if (wasmExecTxs.length !== 0) {
         console.log('Found transaction(s) interacting with our contract(s) on this block…')
         await addSeenHeight(height)

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
   settings,
   CHAIN_REGISTRY_URLS,
   TIMEOUT,
-  updateStateTimerId, TIMEOUT_CHECK_CHAIN_REGISTRY
+  updateStateTimerId, TIMEOUT_CHECK_CHAIN_REGISTRY, updateBlocksTimerId
 } from "./variables"
 import {addRPCs, checkForMissedBlocks, setRPCClients, shuffleRPCs, skipRPCs} from "./utils"
 import fetch from 'node-fetch'
@@ -47,7 +47,7 @@ const setup = async () => {
   setInterval(() => addTxDetail(), TIMEOUT * 2)
 
   // Check for gaps in blocks
-  setInterval(() => checkForMissedBlocks(), TIMEOUT * 2)
+  updateBlocksTimerId(setTimeout(checkForMissedBlocks, TIMEOUT * 2));
 
   // Check for fk_contract_id in messages
   setInterval(() => addContractId(), TIMEOUT * 2)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,7 @@ import {
     blockHeights,
     RPC_LIMIT,
     setAllRPCConnections, SKIP_RPC_ADDRESSES, TIMEOUT,
-    updateBlockHeights, VERBOSITY
+    updateBlockHeights, updateBlocksTimerId, VERBOSITY
 } from "./variables";
 import {BlockResponse, HttpBatchClient, Tendermint34Client, TxResponse} from "@cosmjs/tendermint-rpc";
 import {QueryClient} from "@cosmjs/stargate";
@@ -96,7 +96,8 @@ export const checkForMissedBlocks = async () => {
     // We use length - 1 since we can't compare past that
     for (let i = 0; i < blockHeights.length - 1; i++) {
         // Go until we see the first gap, keep it simple
-        if (blockHeights[i] - blockHeights[i + 1] !== 1) {
+        // blockHeights[i] can't be less or equal to blockHeights[i + 1]
+        if (blockHeights[i] - blockHeights[i + 1] > 1) {
             keepGoing = true
             // Do stuff to add block
             const missingBlockNum = blockHeights[i] - 1
@@ -106,10 +107,10 @@ export const checkForMissedBlocks = async () => {
             const isoBlockTime = new Date(blockTime.toISOString()).toISOString()
             v('isoBlockTime', isoBlockTime)
 
-            console.log('Fixing missed block', missingBlockNum)
             await handleBlockTxs(missingBlockNum, blockTxs, isoBlockTime)
         }
     }
+    updateBlocksTimerId(setTimeout(checkForMissedBlocks, TIMEOUT));
 }
 
 // Credit to Fisher-Yates, SO and eventually https://www.webmound.com/shuffle-javascript-array

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,6 +107,7 @@ export const checkForMissedBlocks = async () => {
             const isoBlockTime = new Date(blockTime.toISOString()).toISOString()
             v('isoBlockTime', isoBlockTime)
 
+            console.log('Fixing missed block', missingBlockNum)
             await handleBlockTxs(missingBlockNum, blockTxs, isoBlockTime)
         }
     }

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -50,4 +50,9 @@ export const updateStateTimerId = (newTimer) => {
     getStateTimerId = newTimer
 }
 
+export let getBlocksTimerId
+export const updateBlocksTimerId = (newBlocksTimer) => {
+    getBlocksTimerId = newBlocksTimer
+}
+
 export const db = getDb()


### PR DESCRIPTION
Close #14 

I couldn't catch this error, so I changed timeout for `checkForLatestBlock`:
```
 setInterval(() => {
    checkForLatestBlock()
  }, TIMEOUT * 7)
```
This way indexer misses blocks more often and in less than 10 minutes I received this error. I think this change doesn't impact the issue.

I checked some logs and I think the problem is in scheduling `checkForMissedBlocks`, it seems like new  `checkForMissedBlocks` starts before the previous one is complete, thus `blockHeights` isn't updated and the last missed block is added twice.

So I changed the scheduling of `checkForMissedBlocks` so that in starts executing only after the previous one is finished. I ran it for some time and I think it is fixed.
